### PR TITLE
Add union field match question

### DIFF
--- a/questions/000-union-field-match.md
+++ b/questions/000-union-field-match.md
@@ -1,0 +1,37 @@
+Answer: 1065353216
+Difficulty: 2
+
+# Hint
+
+Unions have no notion of "active" fields. 
+`#[repr(C)]` guarantees there is no undefined behaviour in this case. 
+
+# Explanation
+
+Union field access [is analogous][reference] to a transmute to the field's type,
+so the match block is roughly equivalent to: 
+
+```rust 
+match u {
+    U { f1 } if std::mem::transmute<U, i32>(u) == 1 => 
+        std::mem::transmute<U, i32>(u), 
+    U { f1 } => std::mem::transmute<U, i32>(u), 
+    U { f2 } => std::mem::transmute<U, f32>(u) as i32, 
+}
+```
+
+where the second arm is a wildcard that matches any value after transmuting it 
+to the type of `f1`. 
+
+The compiler helps us out here by warning that the last match arm is unreachable: 
+```
+warning: unreachable pattern
+  --> questions/032-union-field-match.rs:12:9
+   |
+11 |         U { f1: i } => i,
+   |         ----------- matches any value
+12 |         U { f2: f } => (f + 1.0) as i32,
+   |         ^^^^^^^^^^^ unreachable pattern
+   |
+```
+[reference]: https://doc.rust-lang.org/reference/items/unions.html#reading-and-writing-union-fields

--- a/questions/000-union-field-match.rs
+++ b/questions/000-union-field-match.rs
@@ -1,0 +1,15 @@
+#[repr(C)]
+union U {
+    f1: i32,
+    f2: f32,
+}
+
+fn main() {
+    let u = U { f2: 1.0 };
+    let x = unsafe { match u {
+        U { f1: i } if i == 1 => i,
+        U { f1: i } => i,
+        U { f2: f } => (f + 1.0) as i32,
+    }};
+    print!("{}", x);
+}


### PR DESCRIPTION
I was looking at the unions in the Reference and got confused by the pattern matching section: https://doc.rust-lang.org/reference/items/unions.html#pattern-matching-on-unions

A catch-all arm with a union field will transmute all union values to that field's type, which was unexpected for me, even with the unsafe block required for union field accesses. 

It's a little murky, but as far as I can tell this is not undefined behaviour in C, (but *is* in C++) according to:  
- this Stack Overflow question: https://stackoverflow.com/questions/11373203/accessing-inactive-union-member-and-undefined-behavior
- this C standard defect report: http://www.open-std.org/jtc1/sc22/wg14/www/docs/dr_283.htm
> If the member used to access the contents of a union object is not the same as the member last used to store a value in the object, the appropriate part of the object representation of the value is reinterpreted as an object representation in the new type as described in 6.2.6 (a process sometimes called "type punning"). This might be a trap representation.

and in this case, it's not a trap representation. 

The explanation is a little rough. I thought I'd propose the general question idea and see if you'd like to include it. Please let me know whether you'd like me to rework the question details (maybe adding a constant value `1065353216` to make entering the correct answer easier). 