### PR TITLE
Make 032 clearer with an equivalent code example

### DIFF
--- a/questions/032-or-pattern-guard.md
+++ b/questions/032-or-pattern-guard.md
@@ -19,7 +19,7 @@ alternatives in the arm.
 
 The `match` expression is equivalent to:
 
-```
+```rust
 match (1, 2) {
     (x, _) if check(x) => print!("3"),
     (_, x) if check(x) => print!("3"),

--- a/questions/032-or-pattern-guard.md
+++ b/questions/032-or-pattern-guard.md
@@ -8,18 +8,21 @@ behavior that a hint could help identify. Guess both. :/
 
 # Explanation
 
-This question covers two behaviors of `match` arms and guards.
+An `if` guard on a match-arm containing `|` applies to *all* alternatives in the
+match-arm not just to the one it is adjacent to.
 
-First, whether an `if` guard on a match-arm containing `|` applies to *all*
-alternatives in the match-arm or just to the one it is adjacent to. In the quiz
-code, does `check(x)` execute at all for `(x, _)` or does it only cover the `(_,
-x)` case? We would expect `1` would get printed if and only if the former is the
-case. In fact `1` does get printed. A match-arm gets to have at most one `if`
-guard and that guard applies to all the `|`-separated alternatives in the arm.
+In the quiz code, does `check(x)` execute at all for `(x, _)` or does it only
+cover the `(_, x)` case? We would expect `1` would get printed if and only if
+the former is the case. In fact `1` does get printed. A match-arm gets to have
+at most one `if`guard and that guard applies to all the `|`-separated
+alternatives in the arm.
 
-But second, this question also covers a kind of "backtracking" behavior of
-match-arms. After `check(x)` returns false on `(x, _)`, does the whole match-arm
-fail to match at that point or does Rust move on to `(_, x)` and execute the
-guard a second time? We would expect `2` to be printed if and only if the latter
-is the case. In fact `2` does get printed; the guard is being run multiple
-times, once per `|`-separated alternative in the match-arm.
+The `match` expression is equivalent to:
+
+```
+match (1, 2) {
+    (x, _) if check(x) => print!("3"),
+    (_, x) if check(x) => print!("3"),
+    _ => print!("4"),
+}
+```


### PR DESCRIPTION
Introducing the concept of "backtracking" is confusing. The idea can be explained more clearly with the equivalent code example.