### PR TITLE
Update Bootstrap from 4.1.3 to 5.2.3

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:title" content="Rust Quiz" />
     <meta name="twitter:description" content="What is the output of this Rust program?" />
 
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/styles/default.min.css">
     <link rel="stylesheet" href="/rust-quiz/quiz.css">
   </head>
@@ -33,7 +33,7 @@
     <div class="page">
       <div class="container">
         <div class="pt-5">
-          <h2>Rust Quiz<span id="question-number" class="ml-4 notbold d-none">#<span id="current">1</span></span></h2>
+          <h2>Rust Quiz<span id="question-number" class="ms-4 notbold d-none">#<span id="current">1</span></span></h2>
           <p class="lead">What is the output of this Rust program?</p>
         </div>
 
@@ -54,7 +54,7 @@
             <div class="custom-control custom-radio">
               <input id="radio-output" name="paymentMethod" type="radio" class="custom-control-input">
               <label class="custom-control-label" for="radio-output">
-                <span class="mb-3 mr-2">The program is guaranteed to output:</span>
+                <span class="mb-3 me-2">The program is guaranteed to output:</span>
               </label>
               <input type="tel" class="form-control mb-1" id="text-output" autocomplete="off">
               <a id="button-playground" href="#" target="_blank" class="btn btn-sm btn-outline-secondary d-none" role="button">
@@ -76,15 +76,15 @@
           </div>
 
           <div id="nav">
-            <button id="button-submit" class="btn btn-primary mr-2" type="submit">
+            <button id="button-submit" class="btn btn-primary me-2" type="submit">
               Answer
-            </button><button id="button-hint" class="btn btn-sm btn-outline-secondary mr-2" type="button">
+            </button><button id="button-hint" class="btn btn-sm btn-outline-secondary me-2" type="button">
               Hint
-            </button><button id="button-skip" class="btn btn-sm btn-outline-secondary mr-2" type="button">
+            </button><button id="button-skip" class="btn btn-sm btn-outline-secondary me-2" type="button">
               Skip
-            </button><button id="button-reveal" class="btn btn-sm btn-outline-secondary mr-2" type="button">
+            </button><button id="button-reveal" class="btn btn-sm btn-outline-secondary me-2" type="button">
               Reveal<span id="sad"> 😞</span>
-            </button><span id="incorrect" class="ml-4 text-danger text-nowrap d-none">
+            </button><span id="incorrect" class="ms-4 text-danger text-nowrap d-none">
               Incorrect! Try again.
             </span>
           </div>
@@ -114,7 +114,7 @@
     </div>
 
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.min.js" integrity="sha384-cuYeSxntonz0PPNlHhBs68uyIAVpIIOZZ5JqeqvYYIcEL727kskC66kF92t6Xl2V" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/highlight.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/languages/rust.min.js"></script>
     <script src="/rust-quiz/questions.js"></script>


### PR DESCRIPTION
The only breaking change I was able to identify being relevant was:

> - Renamed several utilities to use logical property names instead of directional names with the addition of RTL support:
>
>   - Renamed `.ml-*` and `.mr-*` to `.ms-*` and `.me-*`.

https://getbootstrap.com/docs/5.0/migration/#utilities