### PR TITLE
feat: add simple dark mode

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html  data-bs-theme="" lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
@@ -24,12 +24,12 @@
     <meta name="twitter:title" content="Rust Quiz" />
     <meta name="twitter:description" content="What is the output of this Rust program?" />
 
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/default.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css"  integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" crossorigin="anonymous">
+    <link id="hl-css" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/default.min.css">
     <link rel="stylesheet" href="/rust-quiz/quiz.css">
   </head>
 
-  <body class="bg-light">
+  <body>
     <div class="page">
       <div class="container">
         <div class="pt-5">
@@ -110,13 +110,15 @@
 
       <div id="reset" class="reset d-none">
         <a href="javascript:reset();" class="reset-link"></a>
+        <a class="toggle-theme-link" data-bs-theme-value="light"></a>
       </div>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.min.js" integrity="sha384-cuYeSxntonz0PPNlHhBs68uyIAVpIIOZZ5JqeqvYYIcEL727kskC66kF92t6Xl2V" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js" integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/languages/rust.min.js"></script>
     <script src="/rust-quiz/questions.js"></script>
     <script src="/rust-quiz/quiz.js"></script>
+    <script src="/rust-quiz/theme-toggler.js"></script>
   </body>
 </html>

--- a/docs/quiz.css
+++ b/docs/quiz.css
@@ -79,6 +79,12 @@ p code {
     color: crimson;
 }
 
+pre code {
+  font-size: .875em;
+  color: var(--bs-code-color);
+  word-wrap: break-word;
+}
+
 #form label {
     display: inline !important;
 }
@@ -94,4 +100,34 @@ a code {
 blockquote {
     padding-left: 30px;
     font-style: italic;
+}
+
+.toggle-theme {
+  display: table-row;
+  vertical-align: bottom;
+  text-align: right;
+  height: 0;
+  line-height: 0;
+}
+
+.toggle-theme-link {
+  display: inline-block;
+  height: 0;
+  position: relative;
+  right: 70px;
+  bottom: 10px;
+}
+
+.toggle-theme-link:after {
+  content: "[Toggle Theme]";
+}
+
+[data-bs-theme=dark] p code {
+  --bs-code-color: #dd8888;
+  color: var(--bs-code-color);
+}
+
+[data-bs-theme=light] p code {
+  --bs-code-color: crimson;
+  color: var(--bs-code-color);
 }

--- a/docs/theme-toggler.js
+++ b/docs/theme-toggler.js
@@ -1,0 +1,67 @@
+(() => {
+	"use strict";
+	const hljsStyleCdnDefault =
+		"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/default.min.css";
+	const hljsStyleCdnDark =
+		"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/base16/synth-midnight-terminal-dark.min.css";
+
+	const hlCssLinkTag = document.querySelector("#hl-css");
+	const storedTheme = localStorage.getItem("theme");
+	const cdnMap = {
+		light: hljsStyleCdnDefault,
+		dark: hljsStyleCdnDark,
+	};
+	const getPreferredTheme = () => {
+		if (storedTheme) {
+			return storedTheme;
+		}
+		return window.matchMedia("(prefers-color-scheme: dark)").matches
+			? "dark"
+			: "light";
+	};
+	const setTheme = function (theme) {
+		if (
+			theme === "auto" &&
+			window.matchMedia("(prefers-color-scheme: dark)").matches
+		) {
+			document.documentElement.setAttribute("data-bs-theme", "dark");
+		} else {
+			document.documentElement.setAttribute("data-bs-theme", theme);
+		}
+	};
+	const getToggleToTheme = (currentTheme) =>
+		currentTheme === "dark" ? "light" : "dark";
+	const initTheme = () => {
+		const currentTheme = getPreferredTheme();
+		setTheme(currentTheme);
+		const toggleTargetTheme = getToggleToTheme(currentTheme);
+		hlCssLinkTag.setAttribute("href", cdnMap?.[currentTheme]);
+		document.querySelectorAll("[data-bs-theme-value]").forEach((toggle) => {
+			const toggleTheme = () => {
+				document
+					.querySelectorAll("[data-bs-theme-value]")
+					.forEach((_toggle) => {
+						const targetTheme = getToggleToTheme(
+							document.documentElement.getAttribute("data-bs-theme"),
+						);
+						hlCssLinkTag.setAttribute("href", cdnMap?.[targetTheme]);
+						setTheme(targetTheme);
+						localStorage.setItem("theme", targetTheme);
+					});
+			};
+			console.log("", toggleTargetTheme);
+			toggle.setAttribute("data-bs-theme-value", toggleTargetTheme);
+			toggle.addEventListener("click", toggleTheme);
+		});
+	};
+	initTheme();
+	window
+		.matchMedia("(prefers-color-scheme: dark)")
+		.addEventListener("change", () => {
+			if (storedTheme !== "light" || storedTheme !== "dark") {
+				setTheme(getPreferredTheme());
+			}
+		});
+
+	window.rustQuizSetTheme = setTheme;
+})();


### PR DESCRIPTION
It's work on Firefox and Chrome.

<img width="1501" alt="image" src="https://user-images.githubusercontent.com/24479753/226126708-48e5633c-b15a-4faf-9630-c7fae4a590c1.png">

---

The effect of the css in the `pre code` is as follows.

<img width="1496" alt="image" src="https://user-images.githubusercontent.com/24479753/226126779-ceec447d-984b-42e8-9b4c-dcc5c5d888bb.png">

before is as follows, visually indistinguishable.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/24479753/226127234-d7798c07-00b9-40f4-ba42-3a4bdb7689a2.png">
