### PR TITLE
Update 010-shadowed-trait-object-method.md

### DIFF
--- a/questions/010-shadowed-trait-object-method.md
+++ b/questions/010-shadowed-trait-object-method.md
@@ -16,11 +16,6 @@ This question contains a trait method `Trait::f` as well as an inherent method
 method is literally uncallable. There is currently no syntax in Rust for calling
 the inherent `f` on `dyn Trait`.
 
-If the trait method were named something different and only the inherent method
-were called `f`, then the first two lines of `main` would successfully call the
-inherent method. However, as written with shadowed names, they disambiguate to
-the trait method.
-
 One additional syntax to try would be:
 
 ```rust


### PR DESCRIPTION
remove the docs no longer valid, it will lead to compile error below seems it only resolve to trait method https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=a298a71d069df17aa097457e07debfe4


Compiling playground v0.0.1 (/playground)
error[E0782]: trait objects must include the `dyn` keyword
  --> src/main.rs:18:5
   |
18 |     Trait::f(&true);
   |     ^^^^^
   |
help: add `dyn` keyword before this trait