### PR TITLE
Fix up the explanation of question 37.

### DIFF
--- a/questions/037-lifetime-extension.md
+++ b/questions/037-lifetime-extension.md
@@ -7,21 +7,24 @@ Difficulty: 2
 
 # Explanation
 
-In both cases, since we don't assign the `Drop0` instance to a variable, it is a
-[temporary].
+When `Drop0` is created, in both cases, it's assigned to a [temporary] memory location.
+Temporary memory locations are normally [scoped] to the statement where they're created,
+so the value is dropped at the end of the statement unless it's moved to a new location.
 
-In `let` statements, [temporary lifetime extension][tle] takes place and extends
-the temporary's lifetime until the end of the block, there it is dropped. So `1`
-is printed first, and then the `Drop0` is dropped and `0` is printed.
+In the [assignment] statement, `_ = &Drop0`, the [underscore expression][und_expr] `_`, is used to
+ignore the binding therefore not moving the value and it ends up being dropped at the end of the
+statement. So, `0` is printed first then `1`.
 
-In assignments, however (`_ = ` is a [destructuring assignment][des_assign]
-expression), there is no temporary lifetime extension, and temporaries are
-dropped at the end of the statement. So, `0` is printed first then `1`.
+In contrast, with `let` statements, something called [temporary lifetime extension][tle] can take
+place and extend the lifetime of the temporary until the end of the block containig the `let`.
+For `Drop0`, in the statement `let _ = &Drop0`, this happens because it's the [operand of a borrow
+expression](expr_ext). So even if the value itself doesn't move, the lifetime of the temporary is
+extended until the end of the block and so `1` is printed first then `0`.
 
-This behavior also means that if we would try to use the value after the
-assignment, the compiler will disallow this with a borrow checker error, as the
-value was already dropped.
 
+[scoped]: https://doc.rust-lang.org/stable/reference/destructors.html#r-destructors.scope.temporary
 [temporary]: https://doc.rust-lang.org/stable/reference/expressions.html#temporaries
 [tle]: https://doc.rust-lang.org/stable/reference/destructors.html#temporary-lifetime-extension
-[des_assign]: https://rust-lang.github.io/rfcs/2909-destructuring-assignment.html
+[assignment]: https://doc.rust-lang.org/stable/reference/expressions/operator-expr.html?highlight=destructuring#r-expr.assign.destructure
+[und_expr]: https://doc.rust-lang.org/stable/reference/expressions/underscore-expr.html?highlight=underscore#_-expressions
+[expr_ext]: https://doc.rust-lang.org/stable/reference/destructors.html#r-destructors.scope.lifetime-extension.exprs

--- a/questions/037-lifetime-extension.md
+++ b/questions/037-lifetime-extension.md
@@ -12,11 +12,11 @@ Temporary memory locations are normally [scoped] to the statement where they're 
 so the value is dropped at the end of the statement unless it's moved to a new location.
 
 In the [assignment] statement, `_ = &Drop0`, the [underscore expression][und_expr] `_`, is used to
-ignore the binding therefore not moving the value and it ends up being dropped at the end of the
+ignore the binding, therefore not moving the value, and it ends up being dropped at the end of the
 statement. So, `0` is printed first then `1`.
 
 In contrast, with `let` statements, something called [temporary lifetime extension][tle] can take
-place and extend the lifetime of the temporary until the end of the block containig the `let`.
+place and extend the lifetime of the temporary until the end of the block containing the `let`.
 For `Drop0`, in the statement `let _ = &Drop0`, this happens because it's the [operand of a borrow
 expression](expr_ext). So even if the value itself doesn't move, the lifetime of the temporary is
 extended until the end of the block and so `1` is printed first then `0`.


### PR DESCRIPTION
Before this patch, the explanation to this question wasn't completely correct, as the creation of temporaries isn't linked to the use of wildcard expressions.

This is important because if one is to follow the current explanation something like

```rs
let _ = Drop0;
println!("1");

```

Would print `10` and this is not the case, since lifetime extensions based on expressions only happens for the operands of borrow operators.

This patch updates the explanation to be a bit more precise according to the reference, and it also corrects a mix up between wildcard pattern and underscore expressions.

Fixes #91